### PR TITLE
#10: Fix rank type coercion and relative redirect handling

### DIFF
--- a/scraper/common.py
+++ b/scraper/common.py
@@ -14,7 +14,7 @@ import json
 import re
 import tempfile
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import requests
 
@@ -129,10 +129,13 @@ def fetch_profile(label: str, profile_url: str) -> dict | None:
         redirects = 0
         while resp.status_code in (301, 302, 303, 307, 308) and redirects < 5:
             location = resp.headers.get("Location", "")
-            if not _is_polymarket_host(location):
+            # Resolve relative redirects (e.g. /profile/...) against current URL
+            resolved = urljoin(url, location)
+            if not _is_polymarket_host(resolved):
                 print(f"  WARN: {label} redirected to non-polymarket host: {location}")
                 return None
-            resp = SESSION.get(location, timeout=30, allow_redirects=False)
+            url = resolved
+            resp = SESSION.get(url, timeout=30, allow_redirects=False)
             redirects += 1
         if resp.status_code != 200:
             print(f"  WARN: {label} HTTP {resp.status_code}")

--- a/scraper/discover.py
+++ b/scraper/discover.py
@@ -353,7 +353,8 @@ def main():
             continue
 
         raw_username = trader.get("userName") or ""
-        rank = trader.get("rank")
+        raw_rank = trader.get("rank")
+        rank = int(raw_rank) if raw_rank is not None else None
         volume = to_float(trader.get("vol"))
 
         # TB2: Validate slug before URL construction — refuse rather than sanitize


### PR DESCRIPTION
## Summary
- **discover.py**: Convert API `rank` field from string to int at storage time, preventing `TypeError` in diff report rank subtraction on second+ runs
- **common.py**: Use `urljoin()` to resolve relative `Location` headers against request origin before SSRF validation. Relative redirects (e.g. `/profile/0x...`) are same-origin by definition.

## Root cause
5 Whys analysis on CI failure. See #10 for full writeup.

## Test plan
- [ ] Trigger `discover.yml` workflow — should complete without TypeError
- [ ] Candidates with wallet-based slugs should get profile enrichment via relative redirect

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)