### PR TITLE
#10: Coerce prev_rank from existing candidates.json

### DIFF
--- a/scraper/discover.py
+++ b/scraper/discover.py
@@ -392,7 +392,8 @@ def main():
 
         style = classify_style(trades, volume)
         first_seen = prev.get("first_seen", today) if prev else today
-        prev_rank = prev.get("leaderboard_rank") if prev else None
+        raw_prev_rank = prev.get("leaderboard_rank") if prev else None
+        prev_rank = int(raw_prev_rank) if raw_prev_rank is not None else None
 
         candidate = {
             "wallet": wallet,


### PR DESCRIPTION
## Summary
- Coerce `prev_rank` read from existing `candidates.json` to int — previous run stored rank as string, causing `int - str` TypeError in diff report

Follow-up to PR #11 which fixed API rank coercion but missed the stored value path.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)