### PR TITLE
#13: Accelerate Goldsky pipeline backfill

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -33,4 +33,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/profiles.json scraper/dune-performance.csv scraper/goldsky_state.json
           git diff --cached --quiet || git commit -m "data: refresh profiles $(date -u +%Y-%m-%d)"
+          git pull --rebase
           git push

--- a/scraper/goldsky_pipeline.py
+++ b/scraper/goldsky_pipeline.py
@@ -34,7 +34,7 @@ GOLDSKY_URL = (
 )
 GAMMA_URL = "https://gamma-api.polymarket.com/markets"
 
-BATCH_SIZE = 200
+BATCH_SIZE = 1000
 MAX_RETRIES = 10
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -127,7 +127,7 @@ def fetch_fills(wallet: str, role: str, last_id: str = ""):
         if len(events) < BATCH_SIZE:
             break
 
-        time.sleep(0.8)
+        time.sleep(0.3)
 
 
 # ---------------------------------------------------------------------------
@@ -620,16 +620,31 @@ def run_pipeline(max_minutes: int | None = None, account_filter: str | None = No
     print(f"Pipeline: {len(work_order)} accounts | max_minutes={max_minutes}")
     print(f"Order: {', '.join(a['name'] for a in work_order[:5])}{'…' if len(work_order) > 5 else ''}")
 
-    for acct in work_order:
-        if time.time() >= deadline:
-            print(f"\nTime budget exhausted ({(time.time() - start) / 60:.1f} min)")
+    for i, acct in enumerate(work_order):
+        now = time.time()
+        if now >= deadline:
+            print(f"\nTime budget exhausted ({(now - start) / 60:.1f} min)")
             break
 
         print(f"\n{'=' * 60}")
         print(f"  {acct['name']} ({acct['wallet'][:12]}…)")
+
+        if deadline == float("inf"):
+            # Unbounded run — no per-account cap
+            account_deadline = deadline
+            print(f"  Budget: unlimited")
+        else:
+            # Fair-share time cap: split remaining budget across remaining accounts
+            remaining_accounts = len(work_order) - i
+            remaining_budget = deadline - now
+            fair_share = remaining_budget / remaining_accounts
+            account_budget = min(max(120, min(fair_share, 3600)), remaining_budget)
+            account_deadline = now + account_budget
+            print(f"  Budget: {account_budget / 60:.1f} min (fair share of {remaining_budget / 60:.1f} min for {remaining_accounts} accounts)")
+
         print(f"{'=' * 60}")
 
-        process_account(acct["name"], acct["wallet"], state, deadline)
+        process_account(acct["name"], acct["wallet"], state, account_deadline)
 
     # Write CSV with all accounts (not just filtered)
     all_accounts: list[dict] = json.loads(ACCOUNTS_FILE.read_text())


### PR DESCRIPTION
## Summary
- **Batch size 200 → 1000** (Graph Protocol max) — 5x fewer round-trips, biggest single throughput gain
- **Inter-batch sleep 0.8s → 0.3s** — retry/backoff handles 429s; combined with 5x batch size, effective request rate drops
- **Per-account fair-share time cap** — remaining budget / remaining accounts, floor 2min, cap 60min, clamped to global deadline; skipped for unbounded runs
- **CI push race fix** — `git pull --rebase` before `git push` prevents lost work when scheduled and manual runs overlap

## Context
Backfill stuck at 1.5/29 accounts after multiple 5hr CI runs. Mega accounts (gabagool22 = 14M fills) consumed the entire time budget, starving smaller accounts.

## Pre-push audit note
Pre-push flagged a pre-existing issue in `query_goldsky()` — it treats `"data": null` GraphQL responses as success. Not in scope for this PR (function not modified), but worth a follow-up.

## Test plan
- [ ] Local dry run: `python3 scraper/goldsky_pipeline.py --max-minutes 5 --accounts Juicy-Trailer` — confirm batch 1000 in logs, fair-share budget
- [ ] Unbounded run: `python3 scraper/goldsky_pipeline.py --accounts Juicy-Trailer` — confirm "Budget: unlimited"
- [ ] Trigger manual CI run, monitor for batch size and per-account allocation
- [ ] Verify state file checkpoint after run

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)